### PR TITLE
Shop Updates

### DIFF
--- a/src/EconomyPlus/EconomyPlayer.php
+++ b/src/EconomyPlus/EconomyPlayer.php
@@ -106,7 +106,8 @@ class EconomyPlayer extends PluginBase{
     if($this->canBuy($price) == false){
       return false;
     }
-    $itm = Item::get(intval($item), 0, intval($amount));
+    $itm = Item::fromString($item);
+    $itm->setCount($amount);
     $this->plugin->getServer()->getPlayer($this->player)->getInventory()->addItem($itm);
     $this->cfg->set(strtolower($this->player), $this->getMoney() - $price);
     $this->cfg->save();
@@ -116,7 +117,8 @@ class EconomyPlayer extends PluginBase{
   }
 
   public function sell(String $item, int $amount, int $price){
-    $itm = Item::get(intval($item), 0, intval($amount));
+    $itm = Item::fromString($item);
+    $itm->setCount($amount);
     if($this->plugin->getServer()->getPlayer($this->player)->getInventory()->contains($itm)){
       $this->cfg->set(strtolower($this->player), $this->getMoney() + $price);
       $this->cfg->save();

--- a/src/EconomyPlus/Shop/SellListener.php
+++ b/src/EconomyPlus/Shop/SellListener.php
@@ -76,7 +76,7 @@ class SellListener extends PluginBase implements Listener{
       if($text[0] == $this->sellprefix){
         $item = substr($text[1], strpos($text[1], "Item: ") + 6);   
         if(Item::fromString($item) instanceof Item){
-          $amount = substr($text[2], strpos($text[2], "amount: ") + 9);
+          $amount = substr($text[2], strpos($text[2], "Amount: ") + 8);
           $price = substr($text[3], strpos($text[3], "Price: ") + 7);
             $eplayer->sell($item, $amount, $price);
         }

--- a/src/EconomyPlus/Shop/ShopListener.php
+++ b/src/EconomyPlus/Shop/ShopListener.php
@@ -36,7 +36,7 @@ class ShopListener extends PluginBase implements Listener{
     * Format
     * [Prefix]
     * [Item]
-    * [amount]
+    * [Amount]
     * [Cost]
     */
     $text = $event->getLines();
@@ -76,7 +76,7 @@ class ShopListener extends PluginBase implements Listener{
       if($text[0] == $this->prefix){
         $item = substr($text[1], strpos($text[1], "Item: ") + 6);   
         if(Item::fromString($item) instanceof Item){
-          $amount = substr($text[2], strpos($text[2], "amount: ") + 9);
+          $amount = substr($text[2], strpos($text[2], "Amount: ") + 8);
           $price = substr($text[3], strpos($text[3], "Price: ") + 7);
           if($eplayer->getMoney() >= $price){ 
             $eplayer->buy($item, $amount, $price);


### PR DESCRIPTION
Updated Shop/Sell Listeners to add support for Item names instead of Item ID's. It does however render all signs that have item ID's useless.